### PR TITLE
Exec sys call (#19)

### DIFF
--- a/pintos/src/threads/thread.c
+++ b/pintos/src/threads/thread.c
@@ -184,6 +184,7 @@ thread_create (const char *name, int priority,
   /* Initialize thread. */
   init_thread (t, name, priority);
   tid = t->tid = allocate_tid ();
+  t->parent_tid = thread_current()->tid;
 
   /* Prepare thread for first run by initializing its stack.
      Do this atomically so intermediate values for the 'stack'
@@ -472,6 +473,12 @@ init_thread (struct thread *t, const char *name, int priority)
   //initialize file list
   list_init (&t->open_files);
   t->next_fd=2;
+
+  // initialize child infrastructure
+  list_init(&t->children);
+  t->child_load = 0;
+  lock_init(&t->child_lock);
+  cond_init(&t->child_condition);
 }
 
 /* Allocates a SIZE-byte frame at the top of thread T's stack and
@@ -587,3 +594,19 @@ allocate_tid (void)
 /* Offset of `stack' member within `struct thread'.
    Used by switch.S, which can't figure it out on its own. */
 uint32_t thread_stack_ofs = offsetof (struct thread, stack);
+
+struct thread
+*thread_get_by_id (tid_t tid)
+{
+  ASSERT (tid != TID_ERROR);
+  struct list_elem *e;
+  struct thread *t;
+  e = list_tail (&all_list);
+  while ((e = list_prev (e)) != list_head (&all_list))
+    {
+      t = list_entry (e, struct thread, allelem);
+      if (t->tid == tid && t->status != THREAD_DYING)
+        return t;
+    }
+  return NULL;
+}

--- a/pintos/src/threads/thread.h
+++ b/pintos/src/threads/thread.h
@@ -4,6 +4,7 @@
 #include <debug.h>
 #include <list.h>
 #include <stdint.h>
+#include "threads/synch.h"
 
 /* States in a thread's life cycle. */
 enum thread_status
@@ -23,6 +24,14 @@ typedef int tid_t;
 #define PRI_MIN 0                       /* Lowest priority. */
 #define PRI_DEFAULT 31                  /* Default priority. */
 #define PRI_MAX 63                      /* Highest priority. */
+
+struct child_status {
+  tid_t child_tid;
+  bool exited;
+  bool waiting;
+  int child_exit_status;
+  struct list_elem elem_child_status;
+};
 
 /* A kernel thread or user process.
 
@@ -90,11 +99,16 @@ struct thread
     int priority;                       /* Priority. */
     struct list_elem allelem;           /* List element for all threads list. */
     struct list open_files;
+    int next_fd;
+    int child_load;
+    struct lock child_lock;
+    struct condition child_condition;
+    struct list children;               /* List of struct child_status elements */
+    tid_t parent_tid;
 
     /* Shared between thread.c and synch.c. */
     struct list_elem elem;              /* List element. */
 
-    int next_fd;
 
 #ifdef USERPROG
     /* Owned by userprog/process.c. */
@@ -140,5 +154,6 @@ int thread_get_nice (void);
 void thread_set_nice (int);
 int thread_get_recent_cpu (void);
 int thread_get_load_avg (void);
+struct thread * thread_get_by_id (tid_t);
 
 #endif /* threads/thread.h */

--- a/pintos/src/userprog/process.h
+++ b/pintos/src/userprog/process.h
@@ -8,33 +8,4 @@ int process_wait (tid_t);
 void process_exit (void);
 void process_activate (void);
 
-/* PCB : see initialization at process_execute(). */
-struct process_control_block {
-
-  int pid;                /* The pid of process */ //change to pid_t
-
-  const char* cmdline;      /* The command line of this process being executed */
-
-  struct list_elem elem;    /* element for thread.child_list */
-  struct thread* parent_thread;    /* the parent process. */
-
-  bool waiting;             /* indicates whether parent process is waiting on this. */
-  bool exited;              /* indicates whether the process is done (exited). */
-  bool orphan;              /* indicates whether the parent process has terminated before. */
-  int32_t exitcode;         /* the exit code passed from exit(), when exited = true */
-
-  /* Synchronization */
-  //struct semaphore sema_initialization;   /* the semaphore used between start_process() and process_execute() */
-  //struct semaphore sema_wait;             /* the semaphore used for wait() : parent blocks until child exits */
-
-};
-
-/* File descriptor */
-struct file_desc {
-  int id;
-  struct list_elem elem;
-  struct file* file;
-  struct dir* dir;        /* In case of directory opening, dir != NULL */
-};
-
 #endif /* userprog/process.h */


### PR DESCRIPTION
* added functionality for user to pass command line arguments (tentative need to test)

added functionality for user to pass command line arguments (tentative
need to test)

* fixed 1st round of errors in process.c

* hex dump

* hexdump

* caught errors

* added printf in hex dump for debugging purposes

* remove print line in hex dump

* debugging to find out why no output from pintos

* debug errs, finding why no out from pintos

* free()s in wrong place: pintos no out

* added output, found out how to get out from pintos

also kernel panic at ../../threads/palloc.c:123 in
palloc_free_multiple() assert pg_ofs (pages) == 0 failed

* print statements for debugging: stack is not right

* more printing... esp

* cast *esp

* i wanted esp is void ** so *esp is the value of esp which is a pointer to where we are in user space men

* trying to get page for hex dump

* printing esp

* this one might work!

* clean up, but working

* add .DS_Store to git ignore

* first round for exec sys call

* typos

* add some includes and global var filesys_lock and fixed typos

* fixed include

* fixed another include

* fixed more includes... and casting some pointers to make compiler happy

* more includes

* include problems...

* cleaning code

* fixing memory leaks

* progress

* infrastructure to keep track of child processes and their load status

infrastructure to keep track of child processes and their load status.

* oops ";"

* oops missing include

* ;s and typos

* added definition of thread_get_by_id and removed unneeded structures

* helpful prints

* not exitting for some reason, debugging

* comment out prints, exec seems to be working with recursor.c example userprog

comment out prints, exec seems to be working with recursor.c example userprog